### PR TITLE
Feature: Gradient blur background implementation

### DIFF
--- a/lib/common/cancel_button.dart
+++ b/lib/common/cancel_button.dart
@@ -1,3 +1,4 @@
+import 'package:bia_app/assets/configs/theme/app_colors.dart';
 import 'package:flutter/material.dart';
 
 class CancelButton extends StatelessWidget {
@@ -22,7 +23,7 @@ class CancelButton extends StatelessWidget {
         style: const TextStyle(
           fontFamily: 'ppneuemontreal',
           fontWeight: FontWeight.w600,
-          color: Colors.grey,
+          color: AppColors.grey,
           fontSize: 16,
           height: 24 / 16,
           letterSpacing: 16 * 0.03,

--- a/lib/presentation/energy_rating/screens/energy_rating_screen.dart
+++ b/lib/presentation/energy_rating/screens/energy_rating_screen.dart
@@ -30,133 +30,158 @@ class _EnergyRatingScreenState extends State<EnergyRatingScreen> {
       body: Column(
         children: [
           Expanded(
-            child: Container(
-              decoration: BoxDecoration(
-                color: AppColors.brown.withOpacity(0.3),
-                borderRadius: const BorderRadius.all(
-                  Radius.circular(30),
-                ),
-              ),
-              child: Stack(
-                alignment: Alignment.center,
-                children: [
-                  Container(
-                    decoration: BoxDecoration(
-                      gradient: RadialGradient(
-                        radius: 0.9,
-                        colors: [
-                          AppColors.primary.withOpacity(0.3),
-                          AppColors.primary.withOpacity(0.2),
-                          AppColors.primary.withOpacity(0.1),
-                          Colors.transparent,
-                        ],
-                        stops: const [0.0, 0.40, 0.60, 1],
-                      ),
-                    ),
-                  ),
-                  Container(
-                    width: double.infinity,
-                    child: Column(
-                      children: [
-                        const SizedBox(height: 48),
-                        Center(
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 36),
-                            child: Text(
-                              'How would you rate your energy this morning?',
-                              textAlign: TextAlign.center,
-                              style: TextStyle(
-                                fontFamily: 'ppneuemontreal',
-                                fontWeight: FontWeight.bold,
-                                color: Colors.white.withOpacity(0.8),
-                                fontSize: 24,
-                                height: 32 / 24,
-                                letterSpacing: 24 * 0.03,
-                              ),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(height: 76),
-                        Center(
-                          child: SvgPicture.asset(
-                            AppVectors.energyIcon,
-                            width: 188,
-                            height: 224,
-                          ),
-                        ),
-                        const SizedBox(height: 84),
-                        const Center(
-                          child: Text(
-                            "I'm feeling great!",
-                            style: TextStyle(
-                              fontFamily: 'ppneuemontreal',
-                              fontWeight: FontWeight.w500,
-                              color: Colors.white,
-                              fontSize: 24,
-                              height: 32 / 24,
-                              letterSpacing: 24 * 0.02,
-                            ),
-                          ),
-                        ),
-                        const SizedBox(height: 24),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 24),
-                          child: Column(
-                            children: [
-                              CustomSlider(
-                                value: _sliderValue,
-                                onChanged: (value) {
-                                  setState(() {
-                                    _sliderValue = value;
-                                  });
-                                },
-                              ),
-                              Row(
-                                mainAxisAlignment:
-                                    MainAxisAlignment.spaceBetween,
-                                children: [
-                                  Text(
-                                    'Worst',
-                                    style: TextStyle(
-                                      color: Colors.white.withOpacity(0.5),
-                                      fontSize: 12,
-                                      fontFamily: 'ppneuemontreal',
-                                      fontWeight: FontWeight.w500,
-                                    ),
-                                  ),
-                                  Text(
-                                    'Best',
-                                    style: TextStyle(
-                                      color: Colors.white.withOpacity(0.5),
-                                      fontSize: 12,
-                                      fontFamily: 'ppneuemontreal',
-                                      fontWeight: FontWeight.w500,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                  )
-                ],
-              ),
-            ),
+            child: _mainContent(),
           ),
-          Container(
-            color: AppColors.layoutBackground,
-            padding: EdgeInsets.fromLTRB(24, 12, 24, 28),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          buttonsContent()
+        ],
+      ),
+    );
+  }
+
+  Widget buttonsContent() {
+    return Container(
+      color: AppColors.layoutBackground,
+      padding: const EdgeInsets.fromLTRB(24, 12, 24, 28),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          CancelButton(title: 'Cancel', onPressed: () {}),
+          ContinueButton(title: 'Continue', onPressed: () {}),
+        ],
+      ),
+    );
+  }
+
+  Widget _mainContent() {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.brown.withOpacity(0.3),
+        borderRadius: const BorderRadius.all(
+          Radius.circular(30),
+        ),
+      ),
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          _backgroundGradient(),
+          SizedBox(
+            width: double.infinity,
+            child: Column(
               children: [
-                CancelButton(title: 'Cancel', onPressed: () {}),
-                ContinueButton(title: 'Continue', onPressed: () {}),
+                const SizedBox(height: 48),
+                _energyQuestionText(),
+                const SizedBox(height: 76),
+                _energyLevelIcon(),
+                const SizedBox(height: 84),
+                _energyStatusDescriptionTect(),
+                const SizedBox(height: 24),
+                _energyRatingSlider(),
               ],
             ),
           )
         ],
+      ),
+    );
+  }
+
+  Widget _energyStatusDescriptionTect() {
+    return const Center(
+      child: Text(
+        "I'm feeling great!",
+        style: TextStyle(
+          fontFamily: 'ppneuemontreal',
+          fontWeight: FontWeight.w500,
+          color: Colors.white,
+          fontSize: 24,
+          height: 32 / 24,
+          letterSpacing: 24 * 0.02,
+        ),
+      ),
+    );
+  }
+
+  Widget _energyQuestionText() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 36),
+      child: Text(
+        'How would you rate your energy this morning?',
+        textAlign: TextAlign.center,
+        style: TextStyle(
+          fontFamily: 'ppneuemontreal',
+          fontWeight: FontWeight.bold,
+          color: Colors.white.withOpacity(0.8),
+          fontSize: 24,
+          height: 32 / 24,
+          letterSpacing: 24 * 0.03,
+        ),
+      ),
+    );
+  }
+
+  Widget _energyLevelIcon() {
+    return Center(
+      child: SvgPicture.asset(
+        AppVectors.energyIcon,
+        width: 188,
+        height: 224,
+      ),
+    );
+  }
+
+  Widget _energyRatingSlider() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Column(
+        children: [
+          CustomSlider(
+            value: _sliderValue,
+            onChanged: (value) {
+              setState(() {
+                _sliderValue = value;
+              });
+            },
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Worst',
+                style: TextStyle(
+                  color: Colors.white.withOpacity(0.5),
+                  fontSize: 12,
+                  fontFamily: 'ppneuemontreal',
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              Text(
+                'Best',
+                style: TextStyle(
+                  color: Colors.white.withOpacity(0.5),
+                  fontSize: 12,
+                  fontFamily: 'ppneuemontreal',
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _backgroundGradient() {
+    return Container(
+      decoration: BoxDecoration(
+        gradient: RadialGradient(
+          radius: 0.95,
+          colors: [
+            AppColors.primary.withOpacity(0.3),
+            AppColors.primary.withOpacity(0.2),
+            AppColors.primary.withOpacity(0.1),
+            Colors.transparent,
+          ],
+          stops: const [0.0, 0.40, 0.60, 1],
+        ),
       ),
     );
   }

--- a/lib/presentation/energy_rating/screens/energy_rating_screen.dart
+++ b/lib/presentation/energy_rating/screens/energy_rating_screen.dart
@@ -30,29 +30,45 @@ class _EnergyRatingScreenState extends State<EnergyRatingScreen> {
       body: Column(
         children: [
           Expanded(
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(40),
+            child: Container(
+              decoration: BoxDecoration(
+                color: AppColors.brown.withOpacity(0.3),
+                borderRadius: const BorderRadius.all(
+                  Radius.circular(30),
+                ),
+              ),
               child: Stack(
                 alignment: Alignment.center,
                 children: [
                   Container(
-                    color: AppColors.brown.withOpacity(0.8),
+                    decoration: BoxDecoration(
+                      gradient: RadialGradient(
+                        radius: 0.9,
+                        colors: [
+                          AppColors.primary.withOpacity(0.3),
+                          AppColors.primary.withOpacity(0.2),
+                          AppColors.primary.withOpacity(0.1),
+                          Colors.transparent,
+                        ],
+                        stops: const [0.0, 0.40, 0.60, 1],
+                      ),
+                    ),
                   ),
                   Container(
                     width: double.infinity,
                     child: Column(
                       children: [
                         const SizedBox(height: 48),
-                        const Center(
+                        Center(
                           child: Padding(
-                            padding: EdgeInsets.symmetric(horizontal: 36),
+                            padding: const EdgeInsets.symmetric(horizontal: 36),
                             child: Text(
                               'How would you rate your energy this morning?',
                               textAlign: TextAlign.center,
                               style: TextStyle(
                                 fontFamily: 'ppneuemontreal',
                                 fontWeight: FontWeight.bold,
-                                color: Colors.white,
+                                color: Colors.white.withOpacity(0.8),
                                 fontSize: 24,
                                 height: 32 / 24,
                                 letterSpacing: 24 * 0.03,
@@ -95,15 +111,15 @@ class _EnergyRatingScreenState extends State<EnergyRatingScreen> {
                                   });
                                 },
                               ),
-                              const Row(
+                              Row(
                                 mainAxisAlignment:
                                     MainAxisAlignment.spaceBetween,
                                 children: [
                                   Text(
                                     'Worst',
                                     style: TextStyle(
-                                      color: Colors.white,
-                                      fontSize: 14,
+                                      color: Colors.white.withOpacity(0.5),
+                                      fontSize: 12,
                                       fontFamily: 'ppneuemontreal',
                                       fontWeight: FontWeight.w500,
                                     ),
@@ -111,8 +127,8 @@ class _EnergyRatingScreenState extends State<EnergyRatingScreen> {
                                   Text(
                                     'Best',
                                     style: TextStyle(
-                                      color: Colors.white,
-                                      fontSize: 14,
+                                      color: Colors.white.withOpacity(0.5),
+                                      fontSize: 12,
                                       fontFamily: 'ppneuemontreal',
                                       fontWeight: FontWeight.w500,
                                     ),


### PR DESCRIPTION
### Description

This PR implement the gradient blur background for the `EnergyRatingScreen`.


### Changes:

- Add an outer background with adjustable opacity to create depth.
- Create an inner background using a `RadialGradient`, applying fixed values to closely replicate the design's effect.

### Screenshots:
> Due to the screenshot quality, the corners of the image are not clearly visible. However, they are properly rendered when running the app.

| View| Description |
| --- | --- |
| <image src="https://github.com/user-attachments/assets/dda5a29e-e810-4545-a27e-2bff3177470a/" controls width="250"> | Without content |
| <image src="https://github.com/user-attachments/assets/a1818e9c-6435-4947-8ac1-2af18123386e/" controls width="250">| With content |

### Notes:

- I attempted to achieve the same effect but struggled to create a pixel-perfect gradient. Additionally, the gradient appears to be oval-shaped instead of circular. I believe this can be resolved with further research, as I couldn't find a parameter to adjust the shape directly.
